### PR TITLE
Migrate extension manifest from V2 to V3

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,8 @@
   "rules": {
     "prettier/prettier": "error",
     "default-case": "off",
-    "react-hooks/exhaustive-deps": "off"
+    "react-hooks/exhaustive-deps": "off",
+    "no-restricted-globals": ["off", { "name": "self" }]
   },
   "env": {
     "browser": true

--- a/background/db/connect.js
+++ b/background/db/connect.js
@@ -3,19 +3,19 @@ let db
 
 export function connectDB(cb) {
   // In the following line, you should include the prefixes of implementations you want to test.
-  if (!window.indexedDB) {
-    window.indexedDB = window.mozIndexedDB || window.webkitIndexedDB || window.msIndexedDB
+  if (!self.indexedDB) {
+    self.indexedDB = self.mozIndexedDB || self.webkitIndexedDB || self.msIndexedDB
   }
   // DON'T use "var indexedDB = ..." if you're not in a function.
   // Moreover, you may need references to some window.IDB* objects:
   // window.IDBTransaction = window.IDBTransaction || window.webkitIDBTransaction || window.msIDBTransaction || { READ_WRITE: 'readwrite' } // This line should only be needed if it is needed to support the object's constants for older browsers
   // window.IDBKeyRange = window.IDBKeyRange || window.webkitIDBKeyRange || window.msIDBKeyRange
   // (Mozilla has never prefixed these objects, so we don't need window.mozIDB*)
-  if (!window.indexedDB) {
+  if (!self.indexedDB) {
     throw new Error("Your browser doesn't support a stable version of IndexedDB. Such and such feature will not be available.")
   }
 
-  const openRequest = window.indexedDB.open('TabsCollectionIDB', 1)
+  const openRequest = self.indexedDB.open('TabsCollectionIDB', 2)
 
   openRequest.onsuccess = function (event) {
     db = openRequest.result

--- a/content/src/components/Home.jsx
+++ b/content/src/components/Home.jsx
@@ -164,7 +164,7 @@ function Home(props) {
               : undefined
           }
         >
-          {menuSelected.current !== undefined && collections[menuSelected.current].list.length > 0 && (
+          {menuSelected.current !== undefined && collections[menuSelected.current]?.list.length > 0 && (
             <MenuItem className="list-text" onClick={openTabs}>
               <ListItemIcon className="list-icon-root">
                 <OpenInBrowserOutlinedIcon className="list-icon" />

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,12 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Tab Collections",
   "description": "Tab Collections",
   "version": "0.1.1",
   "icons": { "16": "logo16.png", "48": "logo48.png", "128": "logo128.png" },
   "permissions": ["storage", "tabs"],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": true
+    "service_worker": "background.js"
   },
   "content_scripts": [
     {
@@ -16,5 +15,5 @@
       "css": ["content.css"]
     }
   ],
-  "browser_action": {}
+  "action": {}
 }


### PR DESCRIPTION
## Background
Chrome group has introduced the [3rd version](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview/) of extension manifest.

The biggest and the only change that affect our extension is that the chrome extension switched from the background page to the service worker.

## What does this PR do?

According to the [migration guide](https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/),  an extension's service worker will start up, do some work, and get terminated repeatedly throughout a user's browser session. Which means using global variable as a long-term state maintanace is no longer stable and should use web storage instead.

So for us, luckily, we only have three variable globally as a state maintanance.

In this PR, we will mainly migrate global variable to local storage, as well as solve some other little problems we will encounter while we're migrating.