### PR TITLE
V1.0.0 Tabs Group Collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 /node_modules
 
 /build

--- a/background/background.js
+++ b/background/background.js
@@ -206,6 +206,20 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
             reloadExtensionContent({ excludeSelf: false })
           })
       }
+      break
+    }
+    case 'open tabs in a group': {
+      const collection = request.payload
+      const openTabPromises = collection.list.map(tabInfo => chrome.tabs.create({ url: tabInfo.url }))
+      Promise.all(openTabPromises).then(tabs => {
+        chrome.tabs
+          .group({
+            tabIds: tabs.map(tab => tab.id),
+          })
+          .then(groupId => {
+            chrome.tabGroups.update(groupId, { title: collection.title })
+          })
+      })
     }
   }
 })

--- a/content/content.scss
+++ b/content/content.scss
@@ -20,9 +20,6 @@ html.tab-collections-pinned {
       width: 22px;
       height: 22px;
     }
-    .home-menu {
-      width: 147px;
-    }
     .tab-collections {
       border-left: 1px solid #d3d2d1;
       * {

--- a/content/src/components/Collection.jsx
+++ b/content/src/components/Collection.jsx
@@ -63,7 +63,6 @@ function Collection(props) {
   }
   useEffect(() => {
     if (prevList.current !== null && list.length !== prevList.current.length) {
-      console.log(list)
       updateCollection({ title, list, id: Number(id) })
     }
   }, [list])

--- a/content/src/components/Collection.jsx
+++ b/content/src/components/Collection.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext, useCallback, useRef } from 'react'
+import React, { useEffect, useState, useContext, useRef } from 'react'
 import { unpin } from '../scripts'
 import { RouteContext } from './Router.jsx'
 import { Paper, Menu, MenuItem, ListItemIcon, InputBase, Link, Divider, Tooltip, Checkbox } from '@material-ui/core'
@@ -42,33 +42,28 @@ function Collection(props) {
     })
   }, [id])
 
-  const updateCollection = useCallback(
-    payload => {
-      if (!pending.current) chrome.runtime.sendMessage({ type: 'update collection', payload })
-    },
-    [list, title]
-  )
-  const handleChange = useCallback(
-    event => {
-      setTitle(event.target.value)
-    },
-    [setTitle]
-  )
-  const handleTitleSave = useCallback(() => {
+  const updateCollection = payload => {
+    if (!pending.current) chrome.runtime.sendMessage({ type: 'update collection', payload })
+  }
+  const handleChange = event => {
+    setTitle(event.target.value)
+  }
+  const handleTitleSave = () => {
     if (title.trim() === '') {
       setTitle(catchedTitle)
       return
     }
     updateCollection({ title, list, id: Number(id) })
-  }, [title, catchedTitle, setTitle])
+  }
 
-  const addCurrentPage = useCallback(() => {
+  const addCurrentPage = () => {
     chrome.runtime.sendMessage({ type: 'get current tab info' }, response => {
       setList([...list, { url: window.location.href, host: window.location.host, title: document.title, favicon: response.favIconUrl }])
     })
-  }, [list, setList])
+  }
   useEffect(() => {
     if (prevList.current !== null && list.length !== prevList.current.length) {
+      console.log(list)
       updateCollection({ title, list, id: Number(id) })
     }
   }, [list])
@@ -76,97 +71,85 @@ function Collection(props) {
     prevList.current = list
   })
 
-  const handleRightClick = useCallback(
-    (index, event) => {
-      event.preventDefault()
-      // block this function if there are selected items
-      if (selectedList.length) {
-        return
-      }
-      menuSelected.current = index
-      setRightClickPosition({ x: event.clientX, y: event.clientY })
-    },
-    [selectedList, setRightClickPosition]
-  )
-  const handleMenuClose = useCallback(() => {
+  const handleRightClick = (index, event) => {
+    event.preventDefault()
+    // block this function if there are selected items
+    if (selectedList.length) {
+      return
+    }
+    menuSelected.current = index
+    setRightClickPosition({ x: event.clientX, y: event.clientY })
+  }
+  const handleMenuClose = () => {
     menuSelected.current = undefined
     setRightClickPosition(null)
-  }, [setRightClickPosition])
+  }
 
-  const deleteOne = useCallback(() => {
+  const deleteOne = () => {
     const deletedList = [...list]
     deletedList.splice(menuSelected.current, 1)
     setList(deletedList)
 
     setRightClickPosition(null)
-  }, [menuSelected.current, setList, setRightClickPosition])
-  const deleteAll = useCallback(() => {
+  }
+  const deleteAll = () => {
     setList([])
     setMoreClickPosition(null)
-  }, [setList, setMoreClickPosition])
-  const deleteSelected = useCallback(() => {
+  }
+  const deleteSelected = () => {
     const temp = [...list]
     selectedList.forEach(i => {
       temp[i] = undefined
     })
     setList(temp.filter(item => item !== undefined))
     setSelectedList([])
-  }, [list, selectedList, setList, setSelectedList])
+  }
 
-  const openOneInNewTab = useCallback(() => {
+  const openOneInNewTab = () => {
     window.open(list[menuSelected.current].url)
     setRightClickPosition(null)
-  }, [menuSelected.current, setRightClickPosition])
-  const openAllInNewTab = useCallback(() => {
+  }
+  const openAllInNewTab = () => {
     list.forEach(item => {
       window.open(item.url)
     })
     setMoreClickPosition(null)
-  }, [list, setMoreClickPosition])
-  const openSelectedInNewTab = useCallback(() => {
+  }
+  const openSelectedInNewTab = () => {
     selectedList.forEach(i => {
       window.open(list[i].url)
     })
     setSelectedList([])
-  }, [list, selectedList, setSelectedList])
+  }
 
-  const openMoreOptionsMenu = useCallback(
-    event => {
-      const position = event.currentTarget.getBoundingClientRect()
-      setMoreClickPosition({ x: position.left, y: position.bottom })
-    },
-    [setMoreClickPosition]
-  )
-  const addAllTabs = useCallback(
-    unpinned => () => {
-      chrome.runtime.sendMessage({ type: 'get tabs info', payload: { unpinned } }, function (response) {
-        setList([
-          ...list,
-          ...response
-            .filter(tab => /^(http|https)/.test(tab.url))
-            .map(tab => ({ url: tab.url, title: tab.title, favicon: tab.favIconUrl, host: tab.url.split('/')[2] })),
-        ])
-        setMoreClickPosition(null)
-      })
-    },
-    [list, setList, setMoreClickPosition]
-  )
+  const openMoreOptionsMenu = event => {
+    const position = event.currentTarget.getBoundingClientRect()
+    setMoreClickPosition({ x: position.left, y: position.bottom })
+  }
+  const addAllTabs = unpinned => () => {
+    chrome.runtime.sendMessage({ type: 'get tabs info', payload: { unpinned } }, function (response) {
+      setList([
+        ...list,
+        ...response
+          .filter(tab => /^(http|https)/.test(tab.url))
+          .map(tab => ({ url: tab.url, title: tab.title, favicon: tab.favIconUrl, host: tab.url.split('/')[2] })),
+      ])
+      setMoreClickPosition(null)
+    })
+  }
 
-  const checkOn = useCallback(
-    idx => {
-      const filtered = selectedList.filter(i => i !== idx)
-      if (filtered.length === selectedList.length) {
-        filtered.push(idx)
-      }
-      setSelectedList(filtered)
-    },
-    [selectedList]
-  )
+  const checkOn = idx => {
+    const filtered = selectedList.filter(i => i !== idx)
+    if (filtered.length === selectedList.length) {
+      filtered.push(idx)
+    }
+    setSelectedList(filtered)
+  }
 
-  const copyUrl = useCallback(() => {
+  const copyUrl = () => {
     copy(list[menuSelected.current].url)
     setRightClickPosition(null)
-  }, [menuSelected.current, setRightClickPosition])
+  }
 
   return (
     <div className="tab-collections-container">

--- a/content/src/components/Home.jsx
+++ b/content/src/components/Home.jsx
@@ -6,6 +6,7 @@ import CloseSharpIcon from '@material-ui/icons/CloseOutlined'
 import AddSharpIcon from '@material-ui/icons/AddSharp'
 import DeleteOutlineOutlined from '@material-ui/icons/DeleteOutlineOutlined'
 import OpenInBrowserOutlinedIcon from '@material-ui/icons/OpenInBrowserOutlined'
+import FolderOpenOutlinedIcon from '@material-ui/icons/FolderOpenOutlined'
 import DeleteOutlineOutlinedIcon from '@material-ui/icons/DeleteOutlineOutlined'
 import MoreHorizOutlinedIcon from '@material-ui/icons/MoreHorizOutlined'
 import PostAddOutlinedIcon from '@material-ui/icons/PostAddOutlined'
@@ -67,6 +68,10 @@ function Home(props) {
     collections[menuSelected.current].list.forEach(item => {
       window.open(item.url)
     })
+    setRightClickPosition(null)
+  }
+  const openTabsInAGroup = () => {
+    chrome.runtime.sendMessage({ type: 'open tabs in a group', payload: collections[menuSelected.current] })
     setRightClickPosition(null)
   }
   const deleteCollection = () => {
@@ -189,7 +194,6 @@ function Home(props) {
           )
         })}
         <Menu
-          classes={{ paper: 'home-menu' }}
           container={document.querySelector('.tab-collections-react-root')}
           autoFocus={false}
           keepMounted
@@ -198,19 +202,29 @@ function Home(props) {
           anchorReference="anchorPosition"
           anchorPosition={
             rightClickPosition
-              ? window.innerWidth - rightClickPosition.x > 147 // 170 is the menu's width
+              ? window.innerWidth - rightClickPosition.x > 245 // 1245 is the menu's width
                 ? { top: rightClickPosition.y, left: rightClickPosition.x }
-                : { top: rightClickPosition.y, left: rightClickPosition.x - 147 }
+                : { top: rightClickPosition.y, left: rightClickPosition.x - 245 }
               : undefined
           }
         >
           {menuSelected.current !== undefined && collections[menuSelected.current]?.list.length > 0 && (
-            <MenuItem className="list-text" onClick={openTabs}>
-              <ListItemIcon className="list-icon-root">
-                <OpenInBrowserOutlinedIcon className="list-icon" />
-              </ListItemIcon>
-              Open all tabs
-            </MenuItem>
+            <>
+              <MenuItem className="list-text" onClick={openTabs}>
+                <ListItemIcon className="list-icon-root">
+                  <OpenInBrowserOutlinedIcon className="list-icon" />
+                </ListItemIcon>
+                Open all tabs
+              </MenuItem>
+              {ENABLE_GROUP_TAB_FEATURE && (
+                <MenuItem className="list-text" onClick={openTabsInAGroup}>
+                  <ListItemIcon className="list-icon-root">
+                    <FolderOpenOutlinedIcon className="list-icon" />
+                  </ListItemIcon>
+                  Open all tabs in a new group
+                </MenuItem>
+              )}
+            </>
           )}
           <MenuItem className="list-text" onClick={deleteCollection}>
             <ListItemIcon className="list-icon-root">

--- a/content/src/components/Home.jsx
+++ b/content/src/components/Home.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState, useRef } from 'react'
+import React, { useContext, useEffect, useState, useRef } from 'react'
 import { unpin } from '../scripts'
 import { RouteContext } from './Router.jsx'
 import { Paper, Link, Menu, MenuItem, ListItemIcon, Checkbox, Tooltip } from '@material-ui/core'
@@ -58,28 +58,25 @@ function Home(props) {
     })
   }
 
-  const handleRightClick = useCallback(
-    (index, event) => {
-      event.preventDefault()
-      menuSelected.current = index
-      setRightClickPosition({ x: event.clientX, y: event.clientY })
-    },
-    [menuSelected.current, setRightClickPosition]
-  )
-  const openTabs = useCallback(() => {
+  const handleRightClick = (index, event) => {
+    event.preventDefault()
+    menuSelected.current = index
+    setRightClickPosition({ x: event.clientX, y: event.clientY })
+  }
+  const openTabs = () => {
     collections[menuSelected.current].list.forEach(item => {
       window.open(item.url)
     })
     setRightClickPosition(null)
-  }, [collections, menuSelected.current, setRightClickPosition])
-  const deleteCollection = useCallback(() => {
+  }
+  const deleteCollection = () => {
     chrome.runtime.sendMessage({ type: 'delete collection', payload: { keys: [collections[menuSelected.current].id] } })
     const temp = [...collections]
     temp.splice(menuSelected.current, 1)
     setCollections(temp)
     setRightClickPosition(null)
-  }, [menuSelected.current, collections, setRightClickPosition])
-  const deleteSelected = useCallback(() => {
+  }
+  const deleteSelected = () => {
     chrome.runtime.sendMessage({ type: 'delete collection', payload: { keys: selectedList.map(idx => collections[idx].id) } })
     const temp = [...collections]
     selectedList.forEach(i => {
@@ -87,22 +84,19 @@ function Home(props) {
     })
     setCollections(temp.filter(c => c !== undefined))
     setSelectedList([])
-  }, [collections, selectedList, setCollections])
-  const handleMenuClose = useCallback(() => {
+  }
+  const handleMenuClose = () => {
     menuSelected.current = undefined
     setRightClickPosition(null)
-  }, [setRightClickPosition])
+  }
 
-  const checkOn = useCallback(
-    idx => {
-      const filtered = selectedList.filter(i => i !== idx)
-      if (filtered.length === selectedList.length) {
-        filtered.push(idx)
-      }
-      setSelectedList(filtered)
-    },
-    [selectedList]
-  )
+  const checkOn = idx => {
+    const filtered = selectedList.filter(i => i !== idx)
+    if (filtered.length === selectedList.length) {
+      filtered.push(idx)
+    }
+    setSelectedList(filtered)
+  }
 
   return (
     <div className="tab-collections-container">

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["*://*/*"],
+      "matches": ["<all_urls>"],
       "js": ["content.js"],
       "css": ["content.css"]
     }

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "description": "Tab Collections",
   "version": "0.1.1",
   "icons": { "16": "logo16.png", "48": "logo48.png", "128": "logo128.png" },
-  "permissions": ["storage", "tabs"],
+  "permissions": ["storage", "tabs", "tabGroups"],
   "background": {
     "service_worker": "background.js"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Tab Collections",
   "description": "Tab Collections",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "icons": { "16": "logo16.png", "48": "logo48.png", "128": "logo128.png" },
   "permissions": ["storage", "tabs", "tabGroups"],
   "background": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tab_collections",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "author": "Shawn Liu",
   "dependencies": {
     "@material-ui/core": "^4.11.1",


### PR DESCRIPTION
# Background
Our extension's initial idea was to help people better manage their tabs. Chrome has come up with a new function called Tab Groups. Which can group tab together. But for production people, like me, I sometimes can also have many tab groups, which is intimidating.

# What does this PR do
So our extension can help here. We can create a collection directly from a group, which is a very good idea. And for the users convenience, the extension should also be able to open all tabs in a collection into a group.