### PR TITLE
Inject content into existing tabs oninstall

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -32,6 +32,19 @@ chrome.runtime.onInstalled.addListener(() => {
   // When a new tab registered, push it in
   localStorage.set({ pin_registry: '' })
   localStorage.set({ location: '/' })
+
+  chrome.tabs.query({}, tabs => {
+    tabs.forEach(tab => {
+      chrome.scripting
+        .executeScript({
+          target: { tabId: tab.id },
+          files: ['content.js'],
+        })
+        .catch(err => {
+          console.log(err) // Usually, caused by an unloaded page, or a chrome internal url to which the extension doesn't have access
+        })
+    })
+  })
 })
 
 function getLocalStorage(key, cb) {

--- a/content/src/scripts/index.js
+++ b/content/src/scripts/index.js
@@ -59,8 +59,11 @@ chrome.runtime.onMessage.addListener(function (request) {
 })
 
 // Create react-dom render container
+const CONTAINER_CLASSNAME = 'tab-collections-react-root'
+const outdatedExtension = document.getElementsByClassName(CONTAINER_CLASSNAME)
+if (outdatedExtension && outdatedExtension.length) outdatedExtension[0].remove()
 const container = document.querySelector('body').appendChild(document.createElement('div'))
-container.className = 'tab-collections-react-root'
+container.className = CONTAINER_CLASSNAME
 
 render(
   <div className="tab-collections" style={{ display: 'none' }}>

--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
   "manifest_version": 3,
   "name": "Tab Collections",
   "description": "Tab Collections",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "icons": { "16": "logo16.png", "48": "logo48.png", "128": "logo128.png" },
-  "permissions": ["storage", "tabs", "tabGroups"],
+  "permissions": ["storage", "tabs", "tabGroups", "scripting"],
   "background": {
     "service_worker": "background.js"
   },
@@ -15,5 +15,6 @@
       "css": ["content.css"]
     }
   ],
+  "host_permissions": ["<all_urls>"],
   "action": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tab_collections",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Shawn Liu",
   "scripts": {
     "build": "gulp build",


### PR DESCRIPTION
Previously on this extension, when the extension is installed, it can't work on the existing tabs. They have to be refrshed to let the extension take effect.

After some investigation, extensions support contentjs being injected dynamically. Thus we can programmatically inject contentjs into existing tabs inside of the onInstalled event callback.